### PR TITLE
Fix connection when Using PowerShell <=5

### DIFF
--- a/PowerArubaIAP/Private/HeaderParsing.ps1
+++ b/PowerArubaIAP/Private/HeaderParsing.ps1
@@ -1,0 +1,39 @@
+#
+# Copyright 2018, Alexis La Goutte <alexis.lagoutte at gmail dot com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+#Code coming from
+# https://stackoverflow.com/questions/35260354/powershell-wget-protocol-violation
+# https://social.technet.microsoft.com/Forums/security/en-US/8ca2eb90-63fe-4f60-9f00-344fc321383b/simple-invokewebrequest-produces-protocol-violation-when-attempting-to-xml-login-to-a-web-based?forum=winserverpowershell
+
+function Set-UseUnsafeHeaderParsing {
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Enable')]
+        [switch]$Enable,
+
+        [Parameter(Mandatory, ParameterSetName = 'Disable')]
+        [switch]$Disable
+    )
+
+    $ShouldEnable = $PSCmdlet.ParameterSetName -eq 'Enable'
+
+    $netAssembly = [Reflection.Assembly]::GetAssembly([System.Net.Configuration.SettingsSection])
+
+    if ($netAssembly) {
+        $bindingFlags = [Reflection.BindingFlags] 'Static,GetProperty,NonPublic'
+        $settingsType = $netAssembly.GetType('System.Net.Configuration.SettingsSectionInternal')
+
+        $instance = $settingsType.InvokeMember('Section', $bindingFlags, $null, $null, @())
+
+        if ($instance) {
+            $bindingFlags = 'NonPublic', 'Instance'
+            $useUnsafeHeaderParsingField = $settingsType.GetField('useUnsafeHeaderParsing', $bindingFlags)
+
+            if ($useUnsafeHeaderParsingField) {
+                $useUnsafeHeaderParsingField.SetValue($instance, $ShouldEnable)
+            }
+        }
+    }
+}

--- a/PowerArubaIAP/Public/Connection.ps1
+++ b/PowerArubaIAP/Public/Connection.ps1
@@ -77,6 +77,8 @@ function Connect-ArubaIAP {
         if ("Desktop" -eq $PSVersionTable.PsEdition) {
             #Remove -SkipCertificateCheck from Invoke Parameter (not supported <= PS 5)
             $invokeParams.remove("SkipCertificateCheck")
+            #Enable UseUnsafeParsingHeader for fix protocol violation when use PS5 (See Bug #2)
+            Set-UseUnsafeHeaderParsing -Enable
         }
         else {
             #Core Edition
@@ -222,6 +224,10 @@ function Disconnect-ArubaIAP {
         if ($decision -eq 0) {
             Write-Progress -activity "Remove Aruba Instant Access Point connection"
             Invoke-ArubaIAPRestMethod -method "Get" -uri $url | Out-Null
+            if ("Desktop" -eq $PSVersionTable.PsEdition) {
+                #Disable UseUnsafeParsingHeader (See Bug #2)
+                Set-UseUnsafeHeaderParsing -Disable
+            }
             Write-Progress -activity "Remove Aruba Instant Access Point connection" -completed
             if (Get-Variable -Name DefaultArubaIAPConnection -scope global) {
                 Remove-Variable -name DefaultArubaIAPConnection -scope global

--- a/PowerArubaIAP/Public/Connection.ps1
+++ b/PowerArubaIAP/Public/Connection.ps1
@@ -102,7 +102,7 @@ function Connect-ArubaIAP {
         $headers = @{ Accept = "application/json"; "Content-type" = "application/json" }
 
         try {
-            $response = Invoke-RestMethod $url -Method POST -Body ($postParams | ConvertTo-Json) -SessionVariable arubaiap -headers $headers  @invokeParams
+            $response = Invoke-RestMethod $url -Method POST -Body ($postParams | ConvertTo-Json) -SessionVariable arubaiap -headers $headers @invokeParams
         }
         catch {
             Show-ArubaIAPException $_
@@ -141,7 +141,7 @@ function Set-ArubaIAPConnection {
         Configure Aruba IAP connection Setting
 
         .DESCRIPTION
-        Configure Aruba IAP connection Setting (IAP IP Addres...)
+        Configure Aruba IAP connection Setting (IAP IP Address...)
 
         .EXAMPLE
         Set-ArubaIAPConnection -iap_ip_addr 192.0.2.2


### PR DESCRIPTION
Fix when connect with PowerShell <= 5 about invalid Protocol, add Set-UnSafeParsingHeader cmdlet for disable validate header...

Fix #2 